### PR TITLE
Fix on windows under mingw

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,10 @@ env:
  - TOXENV=py34
  - TOXENV=pypy
 install:
- - travis_retry pip install tox --use-mirrors
+ - travis_retry pip install tox
+ # virtualenv 14 installs pip8 under tox which breaks py32
+ - |
+    if [ "$TOXENV" = "py32" ]; then
+        pip install 'virtualenv<14'
+    fi
 script: tox

--- a/backports/shutil_get_terminal_size/get_terminal_size.py
+++ b/backports/shutil_get_terminal_size/get_terminal_size.py
@@ -48,9 +48,9 @@ except ImportError:
     def _get_terminal_size(fd):
         try:
             res = fcntl.ioctl(fd, termios.TIOCGWINSZ, b"\x00" * 4)
-            lines, columns = struct.unpack("hh", res)
-        except Exception:
-            columns = lines = 0
+        except IOError as e:
+            raise OSError(e)
+        lines, columns = struct.unpack("hh", res)
 
         return terminal_size(columns, lines)
 

--- a/test_shutil_get_terminal_size.py
+++ b/test_shutil_get_terminal_size.py
@@ -18,6 +18,23 @@ def test_does_not_crash():
     assert size.lines >= 0
 
 
+def test_not_a_tty():
+    proc = subprocess.Popen(
+        (
+            sys.executable, '-c',
+            'import backports.shutil_get_terminal_size as shutil;'
+            'print(tuple(shutil.get_terminal_size((1, 2))))',
+        ),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    out, err = proc.communicate()
+    out, err = out.decode('UTF-8'), err.decode('UTF-8')
+    assert not proc.returncode, (proc.returncode, out, err)
+    assert err == ''
+    assert out == '(1, 2)\n'
+
+
 def test_os_environ_first(monkeypatch):
     "Check if environment variables have precedence"
 


### PR DESCRIPTION
Resolves #4

I based the code on the following from posixmodule.c:

``` c
#ifdef TERMSIZE_USE_CONIO
    {
        DWORD nhandle;
        HANDLE handle;
        CONSOLE_SCREEN_BUFFER_INFO csbi;
        switch (fd) {
        case 0: nhandle = STD_INPUT_HANDLE;
            break;
        case 1: nhandle = STD_OUTPUT_HANDLE;
            break;
        case 2: nhandle = STD_ERROR_HANDLE;
            break;
        default:
            return PyErr_Format(PyExc_ValueError, "bad file descriptor");
        }
        handle = GetStdHandle(nhandle);
        if (handle == NULL)
            return PyErr_Format(PyExc_OSError, "handle cannot be retrieved");
        if (handle == INVALID_HANDLE_VALUE)
            return PyErr_SetFromWindowsErr(0);

        if (!GetConsoleScreenBufferInfo(handle, &csbi))
            return PyErr_SetFromWindowsErr(0);

        columns = csbi.srWindow.Right - csbi.srWindow.Left + 1;
        lines = csbi.srWindow.Bottom - csbi.srWindow.Top + 1;
    }
#endif /* TERMSIZE_USE_CONIO */
```
