### PR TITLE
Bad stdout

### DIFF
--- a/backports/shutil_get_terminal_size/get_terminal_size.py
+++ b/backports/shutil_get_terminal_size/get_terminal_size.py
@@ -89,7 +89,7 @@ def get_terminal_size(fallback=(80, 24)):
     if columns <= 0 or lines <= 0:
         try:
             size = _get_terminal_size(sys.__stdout__.fileno())
-        except (NameError, OSError,AttributeError):
+        except (NameError, OSError, AttributeError):
             size = terminal_size(*fallback)
 
         if columns <= 0:

--- a/backports/shutil_get_terminal_size/get_terminal_size.py
+++ b/backports/shutil_get_terminal_size/get_terminal_size.py
@@ -89,7 +89,7 @@ def get_terminal_size(fallback=(80, 24)):
     if columns <= 0 or lines <= 0:
         try:
             size = _get_terminal_size(sys.__stdout__.fileno())
-        except (NameError, OSError):
+        except (NameError, OSError,AttributeError):
             size = terminal_size(*fallback)
 
         if columns <= 0:


### PR DESCRIPTION
the reason for this fix is slightly complicated : 
when Running IDA Pro with and ipython plugin , ipython calls get_terminal_size when handling certain exceptions.
the probelm is that IDAPythonStdOut doesn't have an attribute fileno. 
AttributeError is raised  and not caught , and the iPython kernel crashes. 
I think it makes sense to catch it here and return the default values . 
would help with other cases where the stdout  object is weird (even if it's not very common).  

